### PR TITLE
Add incremental and date filter tar functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target
 working-dir/
 blob-store/
+mirror-diff/
+*.tar.gz

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,8 +154,10 @@ checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-targets",
 ]
 
@@ -311,6 +313,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "exitcode"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de853764b47027c2e862a995c34978ffa63c1501f2e15f987ba11bd4f9bba193"
+
+[[package]]
 name = "fastrand"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -367,6 +375,12 @@ checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "futures"
@@ -893,12 +907,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+dependencies = [
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.3.1",
+ "rdrand",
+ "winapi",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -943,7 +1003,9 @@ name = "rust-image-mirror"
 version = "0.1.0"
 dependencies = [
  "base64",
+ "chrono",
  "clap",
+ "exitcode",
  "flate2",
  "futures",
  "reqwest",
@@ -954,7 +1016,9 @@ dependencies = [
  "serde_with",
  "serde_yaml",
  "tar",
+ "tempdir",
  "tokio",
+ "walkdir",
 ]
 
 [[package]]
@@ -981,6 +1045,15 @@ name = "ryu"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -1184,6 +1257,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempdir"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
+dependencies = [
+ "rand",
+ "remove_dir_all",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1376,6 +1459,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "walkdir"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1481,6 +1574,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,7 @@ tar = "0.4.38"
 clap = { version = "4.2.4", features = ["derive"] }
 serde_yaml = "0.9.21"
 semver = "1.0.17"
+walkdir = "2.4.0"
+chrono = "0.4.31"
+exitcode = "1.1.2"
+tempdir = "0.3.7"

--- a/src/api/schema.rs
+++ b/src/api/schema.rs
@@ -159,6 +159,14 @@ pub struct Cli {
     /// config file to use
     #[arg(short, long, value_name = "config", default_value = "")]
     pub config: Option<String>,
+
+    /// if set to true will create a diff tar file
+    #[arg(short, long, value_name = "diff-tar", default_value = "false")]
+    pub diff_tar: Option<bool>,
+
+    /// used only in conjuction with --diff-tar with format yyyy/mm/dd (will be ignored otherwise)
+    #[arg(long, value_name = "date", default_value = "")]
+    pub date: Option<String>,
 }
 
 /// config schema

--- a/src/diff/metadata_cache.rs
+++ b/src/diff/metadata_cache.rs
@@ -1,0 +1,125 @@
+use crate::log::logging::*;
+use crate::manifests::catalogs::parse_json_manifest_operator;
+use chrono::NaiveDateTime;
+use exitcode;
+use flate2::write::GzEncoder;
+use flate2::Compression;
+use std::collections::HashSet;
+use std::fs;
+use std::fs::File;
+use std::io::Read;
+use std::path::Path;
+use std::time::SystemTime;
+use tempdir::TempDir;
+use walkdir::WalkDir;
+
+pub fn get_metadata_dirs_by_date(log: &Logging, date: String) -> HashSet<String> {
+    let mut valid_dirs = HashSet::new();
+    let new_date = date + &String::from(" 00:00:00");
+    log.info(&format!("date {:#?}", new_date));
+    let date_only = NaiveDateTime::parse_from_str(&new_date, "%Y/%m/%d %H:%M:%S");
+    match date_only {
+        Ok(val) => val,
+        Err(_) => {
+            log.error("date expected to be in yyyy/mm/dd format");
+            std::process::exit(exitcode::USAGE);
+        }
+    };
+
+    let date_unix = NaiveDateTime::timestamp(&date_only.unwrap());
+    log.info(&format!("date unix {:#?}", date_unix));
+    for e in WalkDir::new("working-dir/".to_string())
+        .into_iter()
+        .filter_map(|e| e.ok())
+    {
+        if e.path().is_dir() {
+            let dir = e.path().display().to_string();
+            let metadata = fs::metadata(&dir).unwrap();
+            let created = metadata
+                .created()
+                .unwrap()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap();
+            if (dir.contains("operators") || dir.contains("release"))
+                && (Path::new(&(dir.clone() + &"/manifest.json".to_string())).exists()
+                    || Path::new(&(dir.clone() + &"/manifest-list.json".to_string())).exists())
+                && created.as_secs() > date_unix as u64
+            {
+                log.hi(&format!(
+                    "timestamp {:#?} for dir {:#?} ",
+                    created.as_secs(),
+                    dir
+                ));
+                valid_dirs.insert(dir);
+            }
+        }
+    }
+    valid_dirs
+}
+
+pub fn get_metadata_dirs_incremental(log: &Logging) -> HashSet<String> {
+    let mut valid_dirs = HashSet::new();
+    for e in WalkDir::new("working-dir/".to_string())
+        .into_iter()
+        .filter_map(|e| e.ok())
+    {
+        if e.path().is_dir() {
+            let dir = e.path().display().to_string();
+            if (dir.contains("operators") || dir.contains("release"))
+                && (Path::new(&(dir.clone() + &"/manifest.json".to_string())).exists()
+                    || Path::new(&(dir.clone() + &"/manifest-list.json".to_string())).exists())
+            {
+                log.info(&format!("valid metadata directories {:#?}", dir));
+                valid_dirs.insert(dir);
+            }
+        }
+    }
+    valid_dirs
+}
+
+pub fn create_diff_tar(
+    log: &Logging,
+    dirs: Vec<&std::string::String>,
+    config: String,
+) -> Result<bool, Box<dyn std::error::Error>> {
+    log.info("creating mirror_diff.tar.gz");
+    let tmp_dir = TempDir::new("tmp-diff-tar")?;
+    let from_base = String::from("working-dir/blobs-store/");
+    fs::create_dir_all(tmp_dir.path().join("metadata"))?;
+    fs::create_dir_all(tmp_dir.path().join("blobs"))?;
+    for x in dirs {
+        // open the manifest file
+        let f = x.to_string() + &"/manifest.json".to_string();
+        let mut fh = File::open(&f)?;
+        // parse the file contents, read it into a Manifest struct
+        let mut s = String::new();
+        let _ = fh.read_to_string(&mut s)?;
+        fs::write(tmp_dir.path().join("manifest.json"), s.clone())?;
+        let mnfst = parse_json_manifest_operator(s.clone()).unwrap();
+        for layer in mnfst.layers.unwrap().iter() {
+            let digest = layer.digest.split(":").nth(1).unwrap();
+            log.info(&format!("layer to copy {:#?}", digest));
+            let to_dir = String::from("blobs/") + digest;
+            let from = from_base.clone() + &digest[..2] + &String::from("/") + digest;
+            let to = tmp_dir.path().join(&to_dir);
+            log.trace(&format!("copy from {:#?} to {:#?}", from, to));
+            fs::copy(from, to)?;
+        }
+        let mnfst_config = mnfst.config.unwrap();
+        let cfg_digest = mnfst_config.digest.split(":").nth(1).unwrap();
+        log.info(&format!("config to copy {:#?}", cfg_digest));
+        let from = from_base.clone() + &cfg_digest[..2] + &String::from("/") + cfg_digest;
+        let to_dir = String::from("blobs/") + cfg_digest;
+        let to = tmp_dir.path().join(&to_dir);
+        fs::copy(from, to)?;
+    }
+    // finally copy over the current imagesetconfig used
+    fs::write(tmp_dir.path().join("metadata/isc.yaml"), config)?;
+    // create the tar
+    let tar_gz = File::create("mirror_diff.tar.gz")?;
+    let enc = GzEncoder::new(tar_gz, Compression::default());
+    let mut tar = tar::Builder::new(enc);
+    tar.append_dir_all(".", tmp_dir.path())?;
+    tmp_dir.close()?;
+    Ok(true)
+}

--- a/src/diff/mod.rs
+++ b/src/diff/mod.rs
@@ -1,0 +1,1 @@
+pub mod metadata_cache;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@
 // use modules
 use clap::Parser;
 use operator::collector::mirror_to_disk;
+use std::collections::HashSet;
 use std::path::Path;
 use tokio;
 
@@ -11,6 +12,7 @@ mod api;
 mod auth;
 mod batch;
 mod config;
+mod diff;
 mod index;
 mod log;
 mod manifests;
@@ -19,6 +21,7 @@ mod operator;
 // use local modules
 use api::schema::*;
 use config::read::*;
+use diff::metadata_cache::*;
 use log::logging::*;
 
 // main entry point (use async)
@@ -32,10 +35,18 @@ async fn main() {
     };
 
     log.info(&format!("rust-image-mirror {} ", cfg));
+    let mut current_cache = HashSet::new();
+
+    if args.diff_tar.unwrap() {
+        if args.date.clone().unwrap().len() == 0 {
+            current_cache = get_metadata_dirs_incremental(log);
+        }
+    }
+    log.info(&format!("directories {:#?} ", current_cache));
 
     // Parse the config serde_yaml::ImageSetConfiguration.
     let config = load_config(cfg).unwrap();
-    let isc_config = parse_yaml_config(config).unwrap();
+    let isc_config = parse_yaml_config(config.clone()).unwrap();
     log.debug(&format!("{:#?}", isc_config.mirror.operators));
 
     // TODO: call release collector
@@ -43,10 +54,28 @@ async fn main() {
     // call operator collector
     // let token = get_token(log,isc_config.mirror.operators)
     mirror_to_disk(log, isc_config.mirror.operators.unwrap()).await;
-    // get_blobs(log, &"", token, images)
+    // get_blobs(log, &"", , images)
 
     // TODO: call additionalImages collector
 
     // let op_url = get_blobs_url_by_string(img.image.clone());
     // get_blobs(log, op_url, token.clone(), fslayers.clone()).await;
+
+    // if flag diff-tar is set create a diff tar.gz
+    if args.diff_tar.unwrap() {
+        let mut new_cache = HashSet::new();
+        log.trace(&format!("new cache {:#?}", new_cache));
+        if args.date.clone().unwrap().len() > 0 {
+            new_cache = get_metadata_dirs_by_date(log, args.date.unwrap());
+        } else {
+            new_cache = get_metadata_dirs_incremental(log);
+        }
+        let diff: Vec<_> = new_cache.difference(&current_cache).collect();
+        log.info(&format!("difference {:#?}", diff));
+        let res = create_diff_tar(log, diff, config);
+        match res {
+            Ok(_) => log.info("mirror-diff.tar.gz successfully created"),
+            Err(err) => log.error(&format!("errror creating diff tar {:#?}", err)),
+        }
+    }
 }

--- a/src/manifests/catalogs.rs
+++ b/src/manifests/catalogs.rs
@@ -31,7 +31,7 @@ pub fn read_operator_catalog(path: String) -> Result<serde_json::Value, Box<dyn 
     Ok(root.overview)
 }
 
-// find a specifc directory in the untar layers
+// find a specific directory in the untar layers
 pub async fn find_dir(log: &Logging, dir: String, name: String) -> String {
     let paths = fs::read_dir(&dir);
     // for both release & operator image indexes


### PR DESCRIPTION
The feature makes use of a --diff-tar cli flag it will do any incremental diffs from a previous execution

If the --dif-tar flag is used with the --date yyyy/mm/dd flag and value it will use all mirroring from the data specified





